### PR TITLE
Refactor APIRoute too allow more subreddits

### DIFF
--- a/CoreAPI/Sources/APIRoute.swift
+++ b/CoreAPI/Sources/APIRoute.swift
@@ -1,12 +1,13 @@
 import Foundation
 
-public enum APIRoute: String {
-    case popular = "/r/popular"
-    case news = "/r/news/"
+public protocol APIRoute {
+    var path: String { get }
+}
 
+extension APIRoute {
     func resolving(baseURL: URL, parameters: [String: String]?) -> URL {
         var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)!
-        components.path = self.rawValue
+        components.path = self.path
         components.queryItems = parameters?.map { URLQueryItem(name: $0, value: $1) }
         return components.url!
     }

--- a/ListingService/Sources/CoreAPI+Listings.swift
+++ b/ListingService/Sources/CoreAPI+Listings.swift
@@ -2,27 +2,14 @@ import CoreAPI
 import Foundation
 
 extension CoreAPI {
-    static func popularListings(afterListing: Listing? = nil,
-                                completion: @escaping (Result<[Listing]>) -> Void) -> URLSessionTask {
+    static func listings(forSubreddit subreddit: SubredditRoute, afterListing: Listing? = nil,
+                         completion: @escaping (Result<[Listing]>) -> Void) -> URLSessionTask {
         var parameters = [String: String]()
         if let listing = afterListing {
             parameters["after"] = listing.fullServerID
         }
 
-        return self.getData(forRoute: .popular, parameters: parameters) { result in
-            let listingsResult = result.map(ListingParser.listings)
-            DispatchQueue.main.async {
-                completion(listingsResult)
-            }
-        }
-    }
-    static func newsListings(afterListing: Listing? = nil,
-                             completion: @escaping (Result<[Listing]>) -> Void) -> URLSessionTask {
-        var parameters = [String: String]()
-        if let listing = afterListing {
-            parameters["after"] = listing.fullServerID
-        }
-        return self.getData(forRoute: .news, parameters: parameters) { result in
+        return self.getData(forRoute: subreddit, parameters: parameters) { result in
             let listingsResult = result.map(ListingParser.listings)
             DispatchQueue.main.async {
                 completion(listingsResult)

--- a/ListingService/Sources/SubredditRoute.swift
+++ b/ListingService/Sources/SubredditRoute.swift
@@ -1,0 +1,19 @@
+import CoreAPI
+import Foundation
+
+public enum SubredditRoute: APIRoute {
+    case popular
+    case news
+    case other(String)
+
+    public var path: String {
+        switch self {
+        case .popular:
+            return "/r/popular"
+        case .news:
+            return "/r/news"
+        case .other(let name):
+            return "/r/" + name
+        }
+    }
+}


### PR DESCRIPTION
APIRoute is now a protocol.

SubredditRoute now defines core subreddits such and news and popular as well as an `other` option which allows for any subreddit.

ListingsDataSource has been updated to use SubredditRoute.