### PR TITLE
Add ImageService which will handle fetching images

### DIFF
--- a/Configs/ImageService.xcconfig
+++ b/Configs/ImageService.xcconfig
@@ -1,0 +1,2 @@
+PRODUCT_BUNDLE_IDENTIFIER = com.gellci.area51os.ImageService
+SKIP_INSTALL = YES

--- a/ImageService/Sources/ImageFetcher.swift
+++ b/ImageService/Sources/ImageFetcher.swift
@@ -1,0 +1,39 @@
+import UIKit
+
+public struct ImageFetcher {
+    private static let session: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.requestCachePolicy = .returnCacheDataElseLoad
+        return URLSession(configuration: config)
+    }()
+
+    private static var currentDownloads = [URL: [ImageDownloadCompletion]]()
+
+    public typealias ImageDownloadCompletion = (UIImage?, URL) -> Void
+
+    /// Will download image data from a url and execute a completion handler when finished.
+    /// If an image for a given url has already been downloaded and cached, it will return the cached version.
+    ///
+    /// - Parameters:
+    ///   - url: The url of the image.
+    ///   - completion: The completion handler returning a UIImage and the url from which it was fetched.
+    public static func image(forURL url: URL, completion: @escaping ImageDownloadCompletion) {
+        if self.currentDownloads.keys.contains(url) {
+            self.currentDownloads[url]?.append(completion)
+            return
+        }
+
+        self.currentDownloads[url] = [completion]
+        self.session.dataTask(with: url) { (data, _, _) in
+            guard let data = data else {
+                return completion(nil, url)
+            }
+
+            let image = UIImage(data: data)
+            DispatchQueue.main.async {
+                self.currentDownloads[url]?.forEach { $0(image, url) }
+                self.currentDownloads.removeValue(forKey: url)
+            }
+        }.resume()
+    }
+}

--- a/ImageService/Sources/NetworkImageView.swift
+++ b/ImageService/Sources/NetworkImageView.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+public class NetworkImageView: UIImageView {
+    /// The url of the image to display.
+    /// Setting the url will trigger the image to be fetched and displayed asynchronously.
+    public var url: URL? {
+        didSet {
+            self.loadImageIfNeeded()
+        }
+    }
+
+    private func loadImageIfNeeded() {
+        guard let url = url else {
+            self.image = nil
+            return
+        }
+
+        ImageFetcher.image(forURL: url) { [weak self] (image, url) in
+            if url == self?.url {
+                self?.image = image
+            }
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -21,6 +21,7 @@ targets:
       Debug: Configs/area51-debug.xcconfig
       Release: Configs/area51-release.xcconfig
     dependencies:
+      - target: ImageService
       - target: ListingService
   CoreAPI:
     type: library.static
@@ -32,6 +33,16 @@ targets:
     configFiles:
       Debug: Configs/CoreAPI.xcconfig
       Release: Configs/CoreAPI.xcconfig
+  ImageService:
+    type: library.static
+    platform: iOS
+    sources:
+      - ImageService/
+    settings:
+      INFOPLIST_FILE: ModuleInfo.plist
+    configFiles:
+      Debug: Configs/ImageService.xcconfig
+      Release: Configs/ImageService.xcconfig
   ListingService:
     type: library.static
     platform: iOS


### PR DESCRIPTION
Adding an ImageFetcher for fetching UIImages from a URL. Handles caching and only fetching a single image for multiple requests of the same image.

Adding NetworkImageView which can be used as an easy way to load an image from a url to an ImageView.