### PR TITLE
Convert Listing to parse JSON via Codable

### DIFF
--- a/CoreAPI/Sources/CoreAPI.swift
+++ b/CoreAPI/Sources/CoreAPI.swift
@@ -7,22 +7,17 @@ public struct CoreAPI {
     private static let baseURL = URL(string: "https://api.reddit.com")!
 
     public static func getData(forRoute route: APIRoute, parameters: [String: String],
-                               completion: @escaping (Result<JSON>) -> Void) -> URLSessionTask {
+                               completion: @escaping (Result<Data>) -> Void) -> URLSessionTask {
         let url = route.resolving(baseURL: self.baseURL, parameters: parameters)
         let task = self.session.dataTask(with: url) { (data, _, _) in
-            guard let data = data else { return }
-            if let json = self.json(from: data) {
-                return completion(Result(success: json))
+            if let data = data {
+                completion(Result(success: data))
+            } else {
+                completion(Result(error: CoreAPIError.random))
             }
-
-            completion(Result(error: CoreAPIError.random))
         }
 
         task.resume()
         return task
-    }
-
-    public static func json(from data: Data) -> JSON? {
-        return (try? JSONSerialization.jsonObject(with: data, options: [])) as? JSON
     }
 }

--- a/ListingService/Sources/Models/Listing.swift
+++ b/ListingService/Sources/Models/Listing.swift
@@ -1,21 +1,25 @@
-import CoreAPI
 import Foundation
 
-public class Listing {
+public class Listing: Decodable {
     public let title: String
     public let url: URL
     let fullServerID: String
 
-    init?(json: JSON) {
-        guard let innerData = json["data"] as? JSON,
-            let title = innerData["title"] as? String,
-            let urlString = innerData["url"] as? String,
-            let fullServerID = innerData["name"] as? String else {
-            return nil
-        }
+    enum CodingKeys: String, CodingKey {
+        case innerData = "data"
+    }
 
-        self.title = title
-        self.fullServerID = fullServerID
-        self.url = URL(string: urlString)!
+    enum InnerDataKeys: String, CodingKey {
+        case title
+        case url
+        case fullServerID = "name"
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let innerData = try values.nestedContainer(keyedBy: InnerDataKeys.self, forKey: .innerData)
+        title = try innerData.decode(String.self, forKey: .title)
+        url = try innerData.decode(URL.self, forKey: .url)
+        fullServerID = try innerData.decode(String.self, forKey: .fullServerID)
     }
 }

--- a/ListingService/Sources/Models/ListingParser.swift
+++ b/ListingService/Sources/Models/ListingParser.swift
@@ -1,12 +1,8 @@
-import CoreAPI
 import Foundation
 
 struct ListingParser {
-    static func listings(from json: JSON) -> [Listing] {
-        guard let jsonData = json["data"] as? JSON, let children = jsonData["children"] as? [JSON] else {
-            return [Listing]()
-        }
-
-        return children.compactMap(Listing.init)
+    static func listings(from data: Data) -> [Listing] {
+        let jsonDecoder = JSONDecoder()
+        return (try? jsonDecoder.decode(ListingResponse.self, from: data).listings) ?? [Listing]()
     }
 }

--- a/ListingService/Sources/Models/ListingResponse.swift
+++ b/ListingService/Sources/Models/ListingResponse.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct ListingResponse: Decodable {
+    let listings: [Listing]
+
+    enum CodingKeys: String, CodingKey {
+        case data
+    }
+
+    enum DataKeys: String, CodingKey {
+        case listings = "children"
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let data = try values.nestedContainer(keyedBy: DataKeys.self, forKey: .data)
+        listings = try data.decode([Listing].self, forKey: .listings)
+    }
+}


### PR DESCRIPTION
Implements #16 

In order to convert Listing to be parsed via Codable, I had to make some changes:
* The `getData` method from CoreAPI now returns the raw `Data` instead of converting it to a JSON dictionary.
* The ListingParser now uses the `JSONDecoder` from Codable.
* The ListingResponse is an intermediary struct, which is also Decodable, that holds the listings array.

Hope this is what you were looking for, I love the idea of this project btw!