### PR TITLE
[ListingTableViewCell] Fixed issue with constraints

### DIFF
--- a/Area51/Resources/UI/TableviewCells/ListingTableViewCell.xib
+++ b/Area51/Resources/UI/TableviewCells/ListingTableViewCell.xib
@@ -25,7 +25,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="80" id="7lZ-z5-4oJ"/>
-                                    <constraint firstAttribute="height" constant="80" id="J93-vV-Gk7"/>
+                                    <constraint firstAttribute="height" priority="750" constant="80" id="J93-vV-Gk7"/>
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Cc5-63-XHE">


### PR DESCRIPTION
From issue #66. I lowered the priority for the image view's height constraint from 1000 to 750 so that it's no longer a required constraint since it's the one the system was breaking. When I check the UI hierarchy in the debugger, it's still keeping the image view's height at 80, in both portrait and landscape.