### PR TITLE
Update image content mode on ListingTableViewCell

### DIFF
--- a/Area51/Resources/UI/TableviewCells/ListingTableViewCell.xib
+++ b/Area51/Resources/UI/TableviewCells/ListingTableViewCell.xib
@@ -21,7 +21,7 @@
                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="xSA-Cb-SVa">
                         <rect key="frame" x="16" y="11" width="288" height="81"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="WYq-7j-qxI" customClass="NetworkImageView" customModule="ImageService">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="WYq-7j-qxI" customClass="NetworkImageView" customModule="ImageService">
                                 <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="80" id="7lZ-z5-4oJ"/>


### PR DESCRIPTION
Use `Aspect Fill` instead of `Scale To Fill` and enable `Clip to Bounds` as mentioned in #65.