### PR TITLE
Trim trailing whitespace and newlines HTML

### DIFF
--- a/Core/Sources/String+Extension.swift
+++ b/Core/Sources/String+Extension.swift
@@ -17,6 +17,6 @@ extension String {
                                                                 return self
         }
 
-        return attributedString.string
+        return attributedString.string.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Core/Tests/CoreTests.swift
+++ b/Core/Tests/CoreTests.swift
@@ -14,4 +14,26 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(result, "Foo")
     }
 
+    func test_strippedHtml_StripsTrailingWhitespace() {
+        // Given
+        let html = "<h1>Foo</h1>"
+
+        // When
+        let result = html.strippedHtml
+
+        // Then
+        XCTAssertEqual(result, "Foo")
+    }
+
+    func test_strippedHtml_DoesNotStripInnerNewlines() {
+        // Given
+        let html = "<h1>Foo<br>Bar</h1>"
+
+        // When
+        let result = html.strippedHtml
+
+        // Then
+        XCTAssertEqual(result, "Foo\u{2028}Bar")
+    }
+
 }


### PR DESCRIPTION
Stripping HTML containing paragraph or heading tags results in a trailing newline. This can be solved by `trimmingCharacters(in: .whitespacesAndNewlines)`.