### PR TITLE
Organise CoreTests into its own folder

### DIFF
--- a/Core/Core.yml
+++ b/Core/Core.yml
@@ -14,7 +14,8 @@ targets:
     type: bundle.unit-test
     platform: iOS
     sources:
-      - Tests
+      - path: Tests
+        name: CoreTests
     settings:
       INFOPLIST_FILE: ModuleInfo.plist
     dependencies:


### PR DESCRIPTION
Previously, the test files were in a `Tests` file in the `.xcodeproject`. Instead, we should put them in their own folder.

Fixes #80