### PR TITLE
Add CoreAPI tests

### DIFF
--- a/CoreAPI/CoreAPI.yml
+++ b/CoreAPI/CoreAPI.yml
@@ -10,3 +10,13 @@ targets:
     configFiles:
       Debug: ../Configs/Module.xcconfig
       Release: ../Configs/Module.xcconfig
+  CoreAPITests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: Tests
+        name: CoreAPITests
+    settings:
+      INFOPLIST_FILE: ModuleInfo.plist
+    dependencies:
+      - target: CoreAPI

--- a/CoreAPI/CoreAPI.yml
+++ b/CoreAPI/CoreAPI.yml
@@ -4,7 +4,6 @@ targets:
     platform: iOS
     sources:
       - path: Sources
-        name: CoreAPI
     settings:
       INFOPLIST_FILE: ../ModuleInfo.plist
     configFiles:
@@ -15,7 +14,6 @@ targets:
     platform: iOS
     sources:
       - path: Tests
-        name: CoreAPITests
     settings:
       INFOPLIST_FILE: ModuleInfo.plist
     dependencies:

--- a/CoreAPI/Sources/CoreAPI.swift
+++ b/CoreAPI/Sources/CoreAPI.swift
@@ -1,13 +1,14 @@
 import Foundation
 
 public struct CoreAPI {
-    private static let session = URLSession(configuration: .default)
     private static let baseURL = URL(string: "https://api.reddit.com")!
 
-    public static func getData(forRoute route: APIRoute, parameters: [String: String],
+    public static func getData(forRoute route: APIRoute,
+                               parameters: [String: String],
+                               session: NetworkSession = URLSession.shared,
                                completion: @escaping (Result<Data>) -> Void) -> URLSessionTask {
         let url = route.resolving(baseURL: self.baseURL, parameters: parameters)
-        let task = self.session.dataTask(with: url) { (data, _, _) in
+        let task = session.dataTask(with: url) { (data, _, _) in
             if let data = data {
                 completion(Result(success: data))
             } else {

--- a/CoreAPI/Sources/NetworkSession.swift
+++ b/CoreAPI/Sources/NetworkSession.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Defines a NetworkSession protocol to allow easier testing
+public protocol NetworkSession {
+    func dataTask(with url: URL, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+}
+
+/// Conform `URLSession` to `NetworkSession`
+extension URLSession: NetworkSession { }

--- a/CoreAPI/Sources/NetworkSession.swift
+++ b/CoreAPI/Sources/NetworkSession.swift
@@ -2,7 +2,8 @@ import Foundation
 
 /// Defines a NetworkSession protocol to allow easier testing
 public protocol NetworkSession {
-    func dataTask(with url: URL, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+    func dataTask(with url: URL,
+                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
 }
 
 /// Conform `URLSession` to `NetworkSession`

--- a/CoreAPI/Tests/APIRouteTests.swift
+++ b/CoreAPI/Tests/APIRouteTests.swift
@@ -30,12 +30,3 @@ class CoreAPITests: XCTestCase {
     }
 
 }
-
-// MARK: - Test Doubles
-
-/// Create a mock which we can control in tests
-class RouterMock: APIRoute {
-    var path: String {
-        return "/test"
-    }
-}

--- a/CoreAPI/Tests/APIRouteTests.swift
+++ b/CoreAPI/Tests/APIRouteTests.swift
@@ -2,7 +2,7 @@
 @testable import CoreAPI
 import XCTest
 
-class CoreAPITests: XCTestCase {
+class APIRouteTests: XCTestCase {
 
     func test_APIRoute_ProducesURL() {
         // Given

--- a/CoreAPI/Tests/APIRouteTests.swift
+++ b/CoreAPI/Tests/APIRouteTests.swift
@@ -1,0 +1,41 @@
+/// Mark CoreAPI as testable so we can access internal functions
+@testable import CoreAPI
+import XCTest
+
+class CoreAPITests: XCTestCase {
+
+    func test_APIRoute_ProducesURL() {
+        // Given
+        let baseURL = URL(string: "https://reddit.com")!
+        let router = RouterMock()
+
+        // When
+        let url = router.resolving(baseURL: baseURL, parameters: nil)
+
+        // Then
+        XCTAssertEqual(url.absoluteString, "https://reddit.com/test")
+    }
+
+    func test_APIRoute_ProducesURL_WithParameters() {
+        // Given
+        let baseURL = URL(string: "https://reddit.com")!
+        let parameters = ["foo": "bar"]
+        let router = RouterMock()
+
+        // When
+        let url = router.resolving(baseURL: baseURL, parameters: parameters)
+
+        // Then
+        XCTAssertEqual(url.absoluteString, "https://reddit.com/test?foo=bar")
+    }
+
+}
+
+// MARK: - Test Doubles
+
+/// Create a mock which we can control in tests
+class RouterMock: APIRoute {
+    var path: String {
+        return "/test"
+    }
+}

--- a/CoreAPI/Tests/CoreAPITestHelpers.swift
+++ b/CoreAPI/Tests/CoreAPITestHelpers.swift
@@ -1,0 +1,29 @@
+import CoreAPI
+import Foundation
+
+/// A partial mock that reports if `.resume()` was called
+class DataTaskMock: URLSessionDataTask {
+    var resumeWasCalled = false
+    override func resume() {
+        resumeWasCalled = true
+    }
+}
+
+/// A network session that allows returning stubbed data
+struct SessionMock: NetworkSession {
+    var data: Data?
+    var response: URLResponse?
+    var error: Error?
+
+    func dataTask(with url: URL, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        completionHandler(data, response, error)
+        return DataTaskMock()
+    }
+}
+
+/// A test route
+class RouterMock: APIRoute {
+    var path: String {
+        return "/test"
+    }
+}

--- a/CoreAPI/Tests/CoreAPITestHelpers.swift
+++ b/CoreAPI/Tests/CoreAPITestHelpers.swift
@@ -15,7 +15,8 @@ struct SessionMock: NetworkSession {
     var response: URLResponse?
     var error: Error?
 
-    func dataTask(with url: URL, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+    func dataTask(with url: URL,
+                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
         completionHandler(data, response, error)
         return DataTaskMock()
     }

--- a/CoreAPI/Tests/CoreAPITests.swift
+++ b/CoreAPI/Tests/CoreAPITests.swift
@@ -11,54 +11,45 @@ class CoreAPITests: XCTestCase {
     }
 
     func test_CoreAPI_GetData_ReturnsDataResult() {
-        let expectation = XCTestExpectation(description: "Returns data")
+        // Given
         let data = "foo".data(using: .utf8)!
         let sessionMock = SessionMock(data: data, response: nil, error: nil)
 
-        _ = CoreAPI.getData(forRoute: route, parameters: [:], session: sessionMock) { result in
-            defer { expectation.fulfill() }
-
-            // Check result
-            switch result {
-            case .success(let returnedData):
-                XCTAssertEqual(returnedData, data)
-            case .error:
-                XCTFail("Result case should be .success")
-            }
+        // When
+        var result: Result<Data>?
+        _ = CoreAPI.getData(forRoute: route, parameters: [:], session: sessionMock) {
+            result = $0
         }
 
-        wait(for: [expectation], timeout: 2.0)
+        // Then
+        assert(result, containsData: data)
     }
 
     func test_CoreAPI_GetData_WithNoData_ReturnsError() {
-        let expectation = XCTestExpectation(description: "Returns error")
+        // Given
         let sessionMock = SessionMock(data: nil, response: nil, error: nil)
 
-        _ = CoreAPI.getData(forRoute: route, parameters: [:], session: sessionMock) { result in
-            defer { expectation.fulfill() }
-
-            // Check result
-            switch result {
-            case .success:
-                XCTFail("Result should not be successful")
-            case .error(let error as CoreAPIError):
-                XCTAssertEqual(error, CoreAPIError.random)
-            case .error:
-                XCTFail("Result should be a CoreAPIError")
-            }
+        // When
+        var theResult: Result<Data>?
+        _ = CoreAPI.getData(forRoute: route, parameters: [:], session: sessionMock) {
+            theResult = $0
         }
 
-        wait(for: [expectation], timeout: 2.0)
+        // Then
+        assert(theResult, containsError: CoreAPIError.random)
     }
 
     func test_CoreAPI_GetData_ResumesTask() {
+        // Given
         let sessionMock = SessionMock(data: nil, response: nil, error: nil)
 
+        // When
         let task = CoreAPI.getData(forRoute: route,
                                    parameters: [:],
                                    session: sessionMock,
                                    completion: { _ in }) as! DataTaskMock
 
+        // Then
         XCTAssertTrue(task.resumeWasCalled)
     }
 }

--- a/CoreAPI/Tests/CoreAPITests.swift
+++ b/CoreAPI/Tests/CoreAPITests.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable force_cast
+
 import CoreAPI
 import XCTest
 
@@ -39,7 +41,6 @@ class CoreAPITests: XCTestCase {
         assert(theResult, containsError: CoreAPIError.random)
     }
 
-    // swiftlint:disable force_cast
     func test_CoreAPI_GetData_ResumesTask() {
         // Given
         let sessionMock = SessionMock(data: nil, response: nil, error: nil)
@@ -53,5 +54,4 @@ class CoreAPITests: XCTestCase {
         // Then
         XCTAssertTrue(task.resumeWasCalled)
     }
-    // swiftlint:enable force_cast
 }

--- a/CoreAPI/Tests/CoreAPITests.swift
+++ b/CoreAPI/Tests/CoreAPITests.swift
@@ -1,0 +1,64 @@
+import CoreAPI
+import XCTest
+
+class CoreAPITests: XCTestCase {
+    /// Use a stubbed route
+    var route: APIRoute!
+
+    override func setUp() {
+        super.setUp()
+        route = RouterMock()
+    }
+
+    func test_CoreAPI_GetData_ReturnsDataResult() {
+        let expectation = XCTestExpectation(description: "Returns data")
+        let data = "foo".data(using: .utf8)!
+        let sessionMock = SessionMock(data: data, response: nil, error: nil)
+
+        _ = CoreAPI.getData(forRoute: route, parameters: [:], session: sessionMock) { result in
+            defer { expectation.fulfill() }
+
+            // Check result
+            switch result {
+            case .success(let returnedData):
+                XCTAssertEqual(returnedData, data)
+            case .error:
+                XCTFail("Result case should be .success")
+            }
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func test_CoreAPI_GetData_WithNoData_ReturnsError() {
+        let expectation = XCTestExpectation(description: "Returns error")
+        let sessionMock = SessionMock(data: nil, response: nil, error: nil)
+
+        _ = CoreAPI.getData(forRoute: route, parameters: [:], session: sessionMock) { result in
+            defer { expectation.fulfill() }
+
+            // Check result
+            switch result {
+            case .success:
+                XCTFail("Result should not be successful")
+            case .error(let error as CoreAPIError):
+                XCTAssertEqual(error, CoreAPIError.random)
+            case .error:
+                XCTFail("Result should be a CoreAPIError")
+            }
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func test_CoreAPI_GetData_ResumesTask() {
+        let sessionMock = SessionMock(data: nil, response: nil, error: nil)
+
+        let task = CoreAPI.getData(forRoute: route,
+                                   parameters: [:],
+                                   session: sessionMock,
+                                   completion: { _ in }) as! DataTaskMock
+
+        XCTAssertTrue(task.resumeWasCalled)
+    }
+}

--- a/CoreAPI/Tests/CoreAPITests.swift
+++ b/CoreAPI/Tests/CoreAPITests.swift
@@ -39,6 +39,7 @@ class CoreAPITests: XCTestCase {
         assert(theResult, containsError: CoreAPIError.random)
     }
 
+    // swiftlint:disable force_cast
     func test_CoreAPI_GetData_ResumesTask() {
         // Given
         let sessionMock = SessionMock(data: nil, response: nil, error: nil)
@@ -52,4 +53,5 @@ class CoreAPITests: XCTestCase {
         // Then
         XCTAssertTrue(task.resumeWasCalled)
     }
+    // swiftlint:enable force_cast
 }

--- a/CoreAPI/Tests/ResultTests.swift
+++ b/CoreAPI/Tests/ResultTests.swift
@@ -1,0 +1,36 @@
+import CoreAPI
+import XCTest
+
+class ResultTests: XCTestCase {
+    func test_Result_Map_WithSuccessCase_CallsTransform() {
+        // Given
+        let input = Result.success(0)
+
+        // When
+        let mappedResult = input.map({ String($0) })
+
+        // Then
+        switch mappedResult {
+        case .success(let str):
+            XCTAssertEqual(str, "0")
+        case .error:
+            XCTFail("Mapped result should be a string")
+        }
+    }
+
+    func test_Result_Map_WithErrorCase_ReturnsError() {
+        // Given
+        let input: Result<String> = Result.error(CoreAPIError.random)
+
+        // When
+        let mappedResult = input.map({ String($0) })
+
+        // Then
+        switch mappedResult {
+        case .error(let error as CoreAPIError):
+            XCTAssertEqual(error, .random)
+        default:
+            XCTFail("Mapped result should be .error(CoreAPIError)")
+        }
+    }
+}

--- a/CoreAPI/Tests/XCTestCase+assert.swift
+++ b/CoreAPI/Tests/XCTestCase+assert.swift
@@ -1,0 +1,47 @@
+import CoreAPI
+import XCTest
+
+// Add a couple of functions to help checking Result types
+extension XCTestCase {
+    /// Assert that a result has expected data
+    ///
+    /// - Parameters:
+    ///   - result: The Result case to check
+    ///   - expectedData: The expected data
+    func assert<T: Equatable>(_ result: Result<T>?,
+                              containsData expectedData: T,
+                              in file: StaticString = #file,
+                              line: UInt = #line) {
+        switch result {
+        case .success(let data)?:
+            XCTAssertEqual(data, expectedData, file: file, line: line)
+        case .error?:
+            XCTFail("Error was thrown", file: file, line: line)
+        case nil:
+            XCTFail("Result was nil", file: file, line: line)
+        }
+    }
+
+    /// Assert that a result has an expected error
+    ///
+    /// - Parameters:
+    ///   - result: The Result case to check
+    ///   - expectedError: The expected Error
+    func assert<T>(_ result: Result<T>?,
+                   containsError expectedError: Error,
+                   in file: StaticString = #file,
+                   line: UInt = #line) {
+        switch result {
+        case .error(let error)?:
+            XCTAssertEqual(
+                error.localizedDescription,
+                expectedError.localizedDescription,
+                file: file, line: line
+            )
+        case .success?:
+            XCTFail("No error thrown", file: file, line: line)
+        case nil:
+            XCTFail("Result was nil", file: file, line: line)
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,11 @@ lint:
 	@./scripts/ensure-swiftlint.sh
 	./tmp/SwiftLint
 
+# List the test schemes in the project
+TEST_SCHEMES = CoreTests CoreAPITests
+
+# Loop through each test scheme and run the tests
 test:
-	xcodebuild test -project Area51.xcodeproj -scheme CoreTests -destination 'name=iPhone X'
+	@(for scheme in $(TEST_SCHEMES) ; do \
+		xcodebuild test -project Area51.xcodeproj -scheme "$${scheme}" -destination 'name=iPhone X'; \
+	done)


### PR DESCRIPTION
Here are some tests for CoreAPI. This tests the current behaviour, but I'd like to see this expanded in the future, as I'll mention below:

**Notes**

- I had to modify the `getData(forRoute:parameters:completion)` method to accept a mocked session. This doesn't affect the call site, thanks to default values.

- CoreAPI currently just returns `CoreAPIError.random` if there is no data. I feel this would be better returning the actual error returned by the `URLSession.dataTask`.

- Additionally, there may be some merit in using the status code from the URL response to check its in the 200-299 range. 

- I modified the `Makefile` to accept an array of test schemes, then look through them to run the tests.