### PR TITLE
Use `createIntermediateGroups` in project.yml

### DIFF
--- a/Core/Core.yml
+++ b/Core/Core.yml
@@ -4,7 +4,6 @@ targets:
     platform: iOS
     sources:
       - path: Sources
-        name: Core
     settings:
       INFOPLIST_FILE: ../ModuleInfo.plist
     configFiles:
@@ -15,7 +14,6 @@ targets:
     platform: iOS
     sources:
       - path: Tests
-        name: CoreTests
     settings:
       INFOPLIST_FILE: ModuleInfo.plist
     dependencies:

--- a/CoreAPI/CoreAPI.yml
+++ b/CoreAPI/CoreAPI.yml
@@ -4,7 +4,6 @@ targets:
     platform: iOS
     sources:
       - path: Sources
-        name: CoreAPI
     settings:
       INFOPLIST_FILE: ../ModuleInfo.plist
     configFiles:

--- a/ImageService/ImageService.yml
+++ b/ImageService/ImageService.yml
@@ -4,7 +4,6 @@ targets:
     platform: iOS
     sources:
       - path: Sources
-        name: ImageService
     settings:
       INFOPLIST_FILE: ../ModuleInfo.plist
     configFiles:

--- a/ListingService/ListingService.yml
+++ b/ListingService/ListingService.yml
@@ -4,7 +4,6 @@ targets:
     platform: iOS
     sources:
       - path: Sources
-        name: ListingService
     settings:
       INFOPLIST_FILE: ../ModuleInfo.plist
     configFiles:

--- a/project.yml
+++ b/project.yml
@@ -5,6 +5,7 @@ name: Area51
 options:
   bundleIdPrefix: com.gellci
   transitivelyLinkDependencies: true
+  createIntermediateGroups: true
 include:
   - Area51/Area51.yml
   - Core/Core.yml


### PR DESCRIPTION
As discussed in https://github.com/kgellci/Area51/pull/81#pullrequestreview-208836286

The other option we could do is add `createIntermediateGroups` on a per
target level. So consider whether you always want the Xcode project to
mirror the paths on disk.

See:
https://github.com/yonaskolb/XcodeGen/issues/528